### PR TITLE
Add fastapi hello world route

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Codex React
+
+Este repositório fornece um exemplo simples de aplicação utilizando FastAPI.
+
+## Como executar
+
+Instale as dependências:
+
+```bash
+pip install -r requirements.txt
+```
+
+Inicie o servidor:
+
+```bash
+python main.py
+```
+
+Acesse [http://localhost:8000/](http://localhost:8000/) para ver a mensagem "Hello, world!".

--- a/main.py
+++ b/main.py
@@ -1,5 +1,15 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello, world!"}
+
+
 def main():
-    print("Hello from codex-react!")
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ sniffio==1.3.1
 starlette==0.46.2
 typing-extensions==4.14.0
 typing-inspection==0.4.1
+uvicorn==0.29.0


### PR DESCRIPTION
## Summary
- create a FastAPI app with a hello world endpoint
- document how to run the server
- include `uvicorn` in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851fa064f94832f942d730164bc2bc6